### PR TITLE
Remove url to Slack channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,11 +138,10 @@
             <b>different programming courses</b> that are useful for their
             professional and personal development. If you are a
             <b>member of the GeoLatinas community</b>, contact us via Slack in
-            our
-            <a href="https://geolatinas.slack.com/archives/C011N1X5N4S"
-              >#coding-group</a
-            >
-            channel.
+            our <b>#coding-group</b> channel. If not, please
+            <a href="https://geolatinas.weebly.com/get-involved.html"
+              >join our community</a
+            >.
           </p>
           <div class="row text-center justify-content-around">
             <div class="col-lg-5 col-md-6 col-padding">


### PR DESCRIPTION
Remove url to `#coding-group` Slack channel from website.
Add a reminder to join GeoLatinas with a link to the main website.

Based on decisions made on #19 